### PR TITLE
feat: add `appPreviewBg`

### DIFF
--- a/OrangeTheme.js
+++ b/OrangeTheme.js
@@ -22,6 +22,7 @@ export default create({
   // UI
   appBg: '#fff',
   appContentBg: '#fff',
+  appPreviewBg: '#fff',
   appBorderColor: 'grey',
   appBorderRadius: 4,
 


### PR DESCRIPTION
### Description

This PR introduces a new theme variable named `appPreviewBg` coming from https://github.com/storybookjs/storybook/pull/24575/files#diff-9e4a68624f61cca374805387d2e82eefd5a9a77566eb314b96d9b63bcd5fc92a.

This theme variable is only available from SB 7.6.0 but doesn't break previous usage with SB < 7.6.0 for ODS Storybook Theme users; variable is defined but not used.