### PR TITLE
fix(lib): remove `@` in import for Storybook 9+

### DIFF
--- a/OrangeTheme.js
+++ b/OrangeTheme.js
@@ -9,7 +9,7 @@
  * or see the "LICENSE" file for more details.
  */
 
-import { create } from '@storybook/theming/create';
+import { create } from 'storybook/theming/create';
 
 // Source: https://storybook.js.org/docs/react/configure/theming
 // Tip: When working locally on themes, use the --no-manager-cache option

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 In order to import the theme into Storybook, create new `.storybook/manager.js` file in your project containing:
 
 ```js
-import { addons } from '@storybook/addons';
+import { addons } from 'storybook/manager-api';
 import OrangeTheme from 'ods-storybook-theme/OrangeTheme.js';
 
 addons.setConfig({
@@ -33,6 +33,7 @@ addons.setConfig({
 | ods-storybook-theme | Storybook     |
 | ------------------- | ------------- |
 | 1.x                 | 6.x, 7.x, 8.x |
+| 2.x                 | 9.x           |
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ods-storybook-theme",
-  "version": "1.1.0",
+  "version": "2.0.0",
   "description": "Provides a Storybook theme for Orange",
   "license": "MIT",
   "main": "OrangeTheme.js",


### PR DESCRIPTION
### Description

Remove an `@` in the import that causes:

```sh
X [ERROR] Could not resolve "@storybook/theming/create"

    node_modules/ods-storybook-theme/OrangeTheme.js:12:23:
      12 │ import { create } from '@storybook/theming/create';
         ╵                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~

  You can mark the path "@storybook/theming/create" as external to exclude it from the bundle, which
  will remove this error and leave the unresolved path in the bundle.

Error: Build failed with 1 error:
node_modules/ods-storybook-theme/OrangeTheme.js:12:23: ERROR: Could not resolve "@storybook/theming/create"
    at failureErrorWithLog (.\node_modules\esbuild\lib\main.js:1463:15)
    at .\node_modules\esbuild\lib\main.js:924:25
    at runOnEndCallbacks (.\node_modules\esbuild\lib\main.js:1303:45)
    at buildResponseToResult (.\node_modules\esbuild\lib\main.js:922:7)
    at .\node_modules\esbuild\lib\main.js:949:16
    at responseCallbacks.<computed> (.\node_modules\esbuild\lib\main.js:601:9)
    at handleIncomingPacket (.\node_modules\esbuild\lib\main.js:656:12)
    at Socket.readFromStdout (.\node_modules\esbuild\lib\main.js:579:7)
    at Socket.emit (node:events:519:28)
    at addChunk (node:internal/streams/readable:559:12)
```

### After the PR is merged

Maybe release a new version of the package compatible with Storybook 9+.